### PR TITLE
infer dimensionlessness

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1]
+
+### Changed
+
+- Infer dimensionlessness

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "csvu"
-version = "0.1.0"
+version = "0.1.1"
 description = "CSV files with units in the one-line header"
 readme = "README.md"
 authors = [

--- a/src/csvu/__init__.py
+++ b/src/csvu/__init__.py
@@ -6,11 +6,16 @@ import pint_pandas
 
 def read_csv(filepath: Path) -> pandas.DataFrame:
     raw = pandas.read_csv(filepath)
-    columns, units = zip(*raw.columns.map(lambda c: c.split("/", 1)))
-    raw.columns = [c.rstrip() for c in columns]
-    return raw.astype(
-        dict(zip(raw.columns, [f"pint[{u.strip(' ()')}]" for u in units]))
-    )
+    units = {}
+    for k, c in enumerate(raw):
+        if "/" in c:
+            column, unit = c.split("/", 1)
+        else:
+            column = c
+            unit = "dimensionless"
+        units[column.rstrip()] = f"pint[{unit.strip(' ()')}]"
+    raw.columns = list(units.keys())
+    return raw.astype(units)
 
 
 def write_csv(df: pandas.DataFrame, filepath: Path) -> None:


### PR DESCRIPTION
This canonicalizes an entry without units like "mass fraction" as "mass fraction / dimensionless".  It's only on `read_csv`; `write_csv` still writes canonically as yet.